### PR TITLE
Fix `nearfield_imager` and `singlestationutil` import

### DIFF
--- a/lofarimaging/lofarimaging.py
+++ b/lofarimaging/lofarimaging.py
@@ -11,7 +11,7 @@ from astropy.coordinates import SkyCoord, SkyOffsetFrame, CartesianRepresentatio
 __all__ = ["nearfield_imager", "sky_imager", "ground_imager", "skycoord_to_lmn", "calibrate", "simulate_sky_source",
            "subtract_sources"]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 SPEED_OF_LIGHT = 299792458.0
 
 

--- a/lofarimaging/lofarimaging.py
+++ b/lofarimaging/lofarimaging.py
@@ -118,6 +118,7 @@ def nearfield_imager(visibilities, baseline_indices, freqs, npix_p, npix_q, exte
 
     bl_diff = np.zeros((vis_chunksize, npix_q, npix_p), dtype=np.float64)
     img = np.zeros((npix_q, npix_p), dtype=np.complex128)
+    j2pi = 1j * 2 * np.pi
     for vis_chunkstart in range(0, len(baseline_indices), vis_chunksize):
         vis_chunkend = min(vis_chunkstart + vis_chunksize, baseline_indices.shape[0])
         # For the last chunk, bl_diff_chunk is a bit smaller than bl_diff
@@ -125,13 +126,10 @@ def nearfield_imager(visibilities, baseline_indices, freqs, npix_p, npix_q, exte
         np.add(distances[baseline_indices[vis_chunkstart:vis_chunkend, 0]],
                -distances[baseline_indices[vis_chunkstart:vis_chunkend, 1]], out=bl_diff_chunk)
 
-        # j2pi = 1j * 2 * np.pi
         for ifreq, freq in enumerate(freqs):
-            # v = visibilities[vis_chunkstart:vis_chunkend, ifreq][:, None, None]
-            # lamb = SPEED_OF_LIGHT / freq
+            v = visibilities[vis_chunkstart:vis_chunkend, ifreq][:, None, None]
+            lamb = SPEED_OF_LIGHT / freq
 
-            # v[:,np.newaxis,np.newaxis]*np.exp(-2j*np.pi*freq/c*groundbase_pixels[:,:,:]/c)
-            # groundbase_pixels=nvis x npix x npix
             np.add(img, np.sum(ne.evaluate("v * exp(j2pi * bl_diff_chunk / lamb)"), axis=0), out=img)
     img /= len(freqs) * len(baseline_indices)
 

--- a/lofarimaging/maputil.py
+++ b/lofarimaging/maputil.py
@@ -10,7 +10,7 @@ import mercantile
 
 __all__ = ["get_map", "make_leaflet_map"]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 
 def get_map(lon_min, lon_max, lat_min, lat_max, zoom=19):

--- a/lofarimaging/singlestationutil.py
+++ b/lofarimaging/singlestationutil.py
@@ -19,7 +19,7 @@ from matplotlib.patches import Circle
 import matplotlib.axes as maxes
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from astropy.coordinates import SkyCoord, GCRS, EarthLocation, AltAz, get_sun, get_moon
+from astropy.coordinates import SkyCoord, GCRS, EarthLocation, AltAz, get_sun, get_body
 import astropy.units as u
 from astropy.time import Time
 
@@ -723,7 +723,7 @@ def make_xst_plots(xst_data: np.ndarray,
         'Cen A': SkyCoord(ra=201.36506288*u.deg, dec=-43.01911267*u.deg),
         'Vir A': SkyCoord(ra=187.70593076*u.deg, dec=12.39112329*u.deg),
         '3C295': SkyCoord(ra=212.83527917*u.deg, dec=52.20264444*u.deg),
-        'Moon': get_moon(time=obstime_astropy, location=station_earthlocation).transform_to(gcrs_instance),
+        'Moon': get_body(body = "MOON", time=obstime_astropy, location=station_earthlocation).transform_to(gcrs_instance),
         'Sun': get_sun(time=obstime_astropy).transform_to(gcrs_instance),
         '3C196': SkyCoord(ra=123.40023371*u.deg, dec=48.21739888*u.deg)
     }

--- a/lofarimaging/singlestationutil.py
+++ b/lofarimaging/singlestationutil.py
@@ -37,7 +37,7 @@ __all__ = ["sb_from_freq", "freq_from_sb", "find_caltable", "read_caltable",
            "make_sky_plot", "make_ground_plot", "make_xst_plots", "apply_calibration",
            "get_full_station_name", "get_extent_lonlat", "make_sky_movie", "reimage_sky"]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 # Configurations for HBA observations with a single dipole activated per tile.
 GENERIC_INT_201512 = [0, 5, 3, 1, 8, 3, 12, 15, 10, 13, 11, 5, 12, 12, 5, 2, 10, 8, 0, 3, 5, 1, 4, 0, 11, 6, 2, 4, 9,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lofarimaging"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
   { name="Vanessa Moss", email="moss@astron.nl" },
   { name="Michiel Brentjens" },


### PR DESCRIPTION
Fixes missing variables that were removed as "unused" in #15, closes #16.

The latest versions of astropy have removed `get_moon` as foreseen in #10, this moves the call over to `get_body` so that the module can still be used and closes #10.